### PR TITLE
Update default eclipse-mosquitto version from 1.6.12 to 2.0.15

### DIFF
--- a/code/system_manager/Supervise.py
+++ b/code/system_manager/Supervise.py
@@ -287,7 +287,9 @@ class Supervise(Containers):
             "nuvlaedge.data-gateway": "True"
         }
         try:
-            cmd = "sh -c 'sleep 10 && /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf'"
+            cmd = "sh -c 'sleep 10; " \
+                  "cp /mosquitto-no-auth.conf /mosquitto/config/mosquitto.conf 2>/dev/null; " \
+                  "/usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf'"
             if self.is_cluster_enabled and self.i_am_manager:
                 self.container_runtime.client.services.create(self.data_gateway_image,
                                                               name=name,

--- a/code/system_manager/Supervise.py
+++ b/code/system_manager/Supervise.py
@@ -289,7 +289,7 @@ class Supervise(Containers):
         try:
             cmd = "sh -c 'sleep 10; " \
                   "cp /mosquitto-no-auth.conf /mosquitto/config/mosquitto.conf 2>/dev/null; " \
-                  "/usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf'"
+                  "exec /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf'"
             if self.is_cluster_enabled and self.i_am_manager:
                 self.container_runtime.client.services.create(self.data_gateway_image,
                                                               name=name,

--- a/code/system_manager/Supervise.py
+++ b/code/system_manager/Supervise.py
@@ -294,8 +294,8 @@ class Supervise(Containers):
                 self.container_runtime.client.services.create(self.data_gateway_image,
                                                               name=name,
                                                               hostname=name,
-                                                              labels=labels,
                                                               init=True,
+                                                              labels=labels,
                                                               container_labels=labels,
                                                               networks=[utils.nuvlaedge_shared_net],
                                                               constraints=[
@@ -313,7 +313,6 @@ class Supervise(Containers):
                                                              detach=True,
                                                              labels=labels,
                                                              restart_policy={"Name": "always"},
-                                                             oom_score_adj=-900,
                                                              network=utils.nuvlaedge_shared_net,
                                                              command=cmd
                                                              )

--- a/code/system_manager/Supervise.py
+++ b/code/system_manager/Supervise.py
@@ -52,7 +52,7 @@ class Supervise(Containers):
         self.on_stop_docker_image = self.container_runtime.infer_on_stop_docker_image()
         self.data_gateway_image = os.getenv('NUVLAEDGE_DATA_GATEWAY_IMAGE',
                                             os.getenv('NUVLABOX_DATA_GATEWAY_IMAGE',
-                                                      'eclipse-mosquitto:1.6.12'))
+                                                      'eclipse-mosquitto:2.0.15-openssl'))
         self.data_gateway_object = None
         self.data_gateway_name = os.getenv('NUVLAEDGE_DATA_GATEWAY_NAME',
                                            os.getenv('NUVLABOX_DATA_GATEWAY_NAME',


### PR DESCRIPTION
Using openssl version which is half the size of libressl version.

Fix #37